### PR TITLE
Add Slack file management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This server supports both traditional and modern MCP transport methods:
 Available tools:
 
 - `slack_list_channels` - List public channels in the workspace with pagination
-- `slack_post_message` - Post a new message to a Slack channel
+- `slack_post_message` - Post a new message to a Slack channel (optionally include files or images)
 - `slack_reply_to_thread` - Reply to a specific message thread in Slack
 - `slack_add_reaction` - Add a reaction emoji to a message
 - `slack_get_channel_history` - Get recent messages from a channel
@@ -23,6 +23,11 @@ Available tools:
 - `slack_get_user_profile` - Get a user's profile information
 - `slack_get_user_profiles` - Get multiple users' profile information in bulk (efficient for batch operations)
 - `slack_search_messages` - Search for messages in the workspace
+- `slack_upload_file` - Upload a file and optionally share it
+- `slack_list_files` - List files visible to the authenticated user
+- `slack_get_file_info` - Get metadata about a file
+- `slack_delete_file` - Delete a file the bot owns
+- `slack_send_file` - Send existing files or images in a message
 
 ## Quick Start
 
@@ -47,6 +52,13 @@ You can also create a `.env` file to set these environment variables:
 SLACK_BOT_TOKEN=xoxb-your-bot-token
 SLACK_USER_TOKEN=xoxp-your-user-token
 ```
+
+Your Slack app must include the following OAuth scopes:
+
+- `chat:write` – post messages and share files
+- `files:write` – upload and delete files
+- `files:read` – list and fetch file info
+- Image files are automatically sent using Slack image blocks when possible
 
 ### Usage
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,14 @@ import {
   SearchMessagesResponseSchema,
   ConversationsHistoryResponseSchema,
   ConversationsRepliesResponseSchema,
+  UploadFileRequestSchema,
+  UploadFileResponseSchema,
+  ListFilesRequestSchema,
+  ListFilesResponseSchema,
+  GetFileInfoRequestSchema,
+  GetFileInfoResponseSchema,
+  DeleteFileRequestSchema,
+  SendFileMessageRequestSchema,
 } from './schemas.js';
 
 dotenv.config();
@@ -101,6 +109,32 @@ function createServer(): Server {
     }
   );
 
+  async function buildBlocksFromFileIds(fileIds: string[]) {
+    const infos = await Promise.all(
+      fileIds.map((id) => userClient.files.info({ file: id }))
+    );
+    return infos.map((info, index) => {
+      if (!info.ok || !info.file) {
+        throw new Error(
+          `Failed to fetch file info for ${fileIds[index]}: ${info.error}`
+        );
+      }
+      const file: any = info.file;
+      if (file.mimetype && /^image\//.test(file.mimetype)) {
+        return {
+          type: 'image',
+          image_url: file.url_private,
+          alt_text: file.title ?? file.name ?? 'image',
+        };
+      }
+      return {
+        type: 'file',
+        external_id: file.id,
+        source: 'remote',
+      };
+    });
+  }
+
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
       tools: [
@@ -111,7 +145,7 @@ function createServer(): Server {
         },
         {
           name: 'slack_post_message',
-          description: 'Post a new message to a Slack channel',
+          description: 'Post a new message to a Slack channel (optionally with files)',
           inputSchema: zodToJsonSchema(PostMessageRequestSchema),
         },
         {
@@ -155,6 +189,31 @@ function createServer(): Server {
           description: 'Search for messages in the workspace',
           inputSchema: zodToJsonSchema(SearchMessagesRequestSchema),
         },
+        {
+          name: 'slack_upload_file',
+          description: 'Upload a file and optionally share it to a channel or DM',
+          inputSchema: zodToJsonSchema(UploadFileRequestSchema),
+        },
+        {
+          name: 'slack_list_files',
+          description: 'List files visible to the authenticated user',
+          inputSchema: zodToJsonSchema(ListFilesRequestSchema),
+        },
+        {
+          name: 'slack_get_file_info',
+          description: 'Get metadata about a specific file',
+          inputSchema: zodToJsonSchema(GetFileInfoRequestSchema),
+        },
+        {
+          name: 'slack_delete_file',
+          description: 'Delete a file the bot owns',
+          inputSchema: zodToJsonSchema(DeleteFileRequestSchema),
+        },
+        {
+          name: 'slack_send_file',
+          description: 'Send existing files in a message',
+          inputSchema: zodToJsonSchema(SendFileMessageRequestSchema),
+        },
       ],
     };
   });
@@ -186,10 +245,14 @@ function createServer(): Server {
 
         case 'slack_post_message': {
           const args = PostMessageRequestSchema.parse(request.params.arguments);
-          const response = await slackClient.chat.postMessage({
+          const messageParams: any = {
             channel: args.channel_id,
             text: args.text,
-          });
+          };
+          if (args.file_ids) {
+            messageParams.blocks = await buildBlocksFromFileIds(args.file_ids);
+          }
+          const response = await slackClient.chat.postMessage(messageParams);
           if (!response.ok) {
             throw new Error(`Failed to post message: ${response.error}`);
           }
@@ -380,6 +443,104 @@ function createServer(): Server {
           const parsed = SearchMessagesResponseSchema.parse(response);
           return {
             content: [{ type: 'text', text: JSON.stringify(parsed) }],
+          };
+        }
+
+        case 'slack_upload_file': {
+          const args = UploadFileRequestSchema.parse(request.params.arguments);
+          const fileBuffer = Buffer.from(args.content_base64, 'base64');
+          const reserve = await slackClient.files.getUploadURLExternal({
+            filename: args.filename,
+            length: fileBuffer.length,
+          });
+          if (!reserve.ok || !reserve.upload_url || !reserve.file_id) {
+            throw new Error(`Failed to reserve upload: ${reserve.error}`);
+          }
+          const putResponse = await fetch(reserve.upload_url, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/octet-stream' },
+            body: fileBuffer,
+          });
+          if (!putResponse.ok) {
+            throw new Error(`Failed to upload file bytes: ${putResponse.status}`);
+          }
+          const complete = await slackClient.files.completeUploadExternal({
+            files: [
+              {
+                id: reserve.file_id,
+                title: args.title ?? args.filename,
+              },
+            ],
+            channel_id: args.channel_id,
+          });
+          if (!complete.ok) {
+            throw new Error(`Failed to complete upload: ${complete.error}`);
+          }
+          const parsed = UploadFileResponseSchema.parse({
+            ...complete,
+            file: { id: reserve.file_id },
+          });
+          return {
+            content: [{ type: 'text', text: JSON.stringify(parsed) }],
+          };
+        }
+
+        case 'slack_list_files': {
+          const args = ListFilesRequestSchema.parse(request.params.arguments);
+          const response = await userClient.files.list({
+            user: args.user,
+            channel: args.channel,
+            types: args.types,
+            ts_from: args.ts_from,
+            ts_to: args.ts_to,
+            cursor: args.cursor,
+            limit: args.limit,
+          });
+          if (!response.ok) {
+            throw new Error(`Failed to list files: ${response.error}`);
+          }
+          const parsed = ListFilesResponseSchema.parse(response);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(parsed) }],
+          };
+        }
+
+        case 'slack_get_file_info': {
+          const args = GetFileInfoRequestSchema.parse(request.params.arguments);
+          const response = await userClient.files.info({ file: args.file_id });
+          if (!response.ok) {
+            throw new Error(`Failed to get file info: ${response.error}`);
+          }
+          const parsed = GetFileInfoResponseSchema.parse(response);
+          return {
+            content: [{ type: 'text', text: JSON.stringify(parsed) }],
+          };
+        }
+
+        case 'slack_delete_file': {
+          const args = DeleteFileRequestSchema.parse(request.params.arguments);
+          const response = await slackClient.files.delete({ file: args.file_id });
+          if (!response.ok) {
+            throw new Error(`Failed to delete file: ${response.error}`);
+          }
+          return {
+            content: [{ type: 'text', text: 'File deleted successfully' }],
+          };
+        }
+
+        case 'slack_send_file': {
+          const args = SendFileMessageRequestSchema.parse(request.params.arguments);
+          const blocks = await buildBlocksFromFileIds(args.file_ids);
+          const response = await slackClient.chat.postMessage({
+            channel: args.channel_id,
+            text: args.text ?? '',
+            blocks,
+          });
+          if (!response.ok) {
+            throw new Error(`Failed to send file: ${response.error}`);
+          }
+          return {
+            content: [{ type: 'text', text: 'File sent successfully' }],
           };
         }
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -213,6 +213,11 @@ export const ListChannelsRequestSchema = z.object({
 export const PostMessageRequestSchema = z.object({
   channel_id: z.string().describe('The ID of the channel to post to'),
   text: z.string().describe('The message text to post'),
+  file_ids: z
+    .array(z.string())
+    .nonempty()
+    .optional()
+    .describe('IDs of already uploaded files to include in the message'),
 });
 
 export const ReplyToThreadRequestSchema = z.object({
@@ -350,4 +355,98 @@ export const SearchMessagesResponseSchema = BaseResponseSchema.extend({
       pagination: SearchPaginationSchema.optional(),
     })
     .optional(),
+});
+
+//
+// File-related schemas
+//
+
+export const FileSchema = z
+  .object({
+    id: z.string().optional(),
+    name: z.string().optional(),
+    title: z.string().optional(),
+    mimetype: z.string().optional(),
+    filetype: z.string().optional(),
+    size: z.number().optional(),
+    url_private: z.string().url().optional(),
+    url_private_download: z.string().url().optional(),
+  })
+  .strip();
+
+export const UploadFileRequestSchema = z.object({
+  filename: z.string().describe('Name of the file to upload'),
+  content_base64: z
+    .string()
+    .describe('Base64 encoded file contents to upload'),
+  title: z.string().optional().describe('Title of the file in Slack'),
+  channel_id: z
+    .string()
+    .optional()
+    .describe('Channel or DM conversation ID to share the file'),
+});
+
+export const UploadFileResponseSchema = BaseResponseSchema.extend({
+  file: z
+    .object({
+      id: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const ListFilesRequestSchema = z.object({
+  user: z.string().optional().describe('Filter files created by user ID'),
+  channel: z
+    .string()
+    .optional()
+    .describe('Filter files visible in a channel'),
+  types: z
+    .string()
+    .optional()
+    .describe('Filter by file types (comma separated)'),
+  ts_from: z
+    .number()
+    .optional()
+    .describe('Filter for files created after this timestamp'),
+  ts_to: z
+    .number()
+    .optional()
+    .describe('Filter for files created before this timestamp'),
+  cursor: z
+    .string()
+    .optional()
+    .describe('Pagination cursor for next page of results'),
+  limit: z
+    .number()
+    .int()
+    .min(1)
+    .max(1000)
+    .optional()
+    .default(100)
+    .describe('Maximum number of files to return'),
+});
+
+export const ListFilesResponseSchema = BaseResponseSchema.extend({
+  files: z.array(FileSchema).optional(),
+});
+
+export const GetFileInfoRequestSchema = z.object({
+  file_id: z.string().describe('ID of the file to fetch'),
+});
+
+export const GetFileInfoResponseSchema = BaseResponseSchema.extend({
+  file: FileSchema.optional(),
+});
+
+export const DeleteFileRequestSchema = z.object({
+  file_id: z.string().describe('ID of the file to delete'),
+});
+
+export const SendFileMessageRequestSchema = z.object({
+  channel_id: z.string().describe('Channel or DM to post the file in'),
+  file_ids: z
+    .array(z.string())
+    .nonempty()
+    .describe('IDs of the files to send'),
+  text: z.string().optional().describe('Additional message text'),
 });


### PR DESCRIPTION
## Summary
- handle Slack file uploads with `slack_upload_file`
- list and inspect files
- send files in chat messages
- delete uploaded files
- allow posting messages with file attachments
- document OAuth scopes for file features
- allow list of file IDs in message tools
- send images using image blocks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_i_684dbdf643048320a5b1e0f8ddc1be89